### PR TITLE
 Fix invalid usage of `sinon.sandbox`

### DIFF
--- a/tests/autosave.js
+++ b/tests/autosave.js
@@ -13,7 +13,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import PendingActions from '@ckeditor/ckeditor5-core/src/pendingactions';
 
 describe( 'Autosave', () => {
-	const sandbox = sinon.sandbox.create( { useFakeTimers: true } );
+	const sandbox = sinon.sandbox;
 	let editor, element, autosave;
 
 	afterEach( () => {

--- a/tests/throttle.js
+++ b/tests/throttle.js
@@ -6,9 +6,7 @@
 import throttle from '../src/throttle';
 
 describe( 'throttle', () => {
-	const sandbox = sinon.sandbox.create( {
-		useFakeTimers: true
-	} );
+	const sandbox = sinon.sandbox;
 
 	beforeEach( () => {
 		sandbox.useFakeTimers( { now: 1000 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Fixed invalid usage of `sinon.sandbox`. Closes ckeditor/ckeditor5#1158.
