### PR TITLE
Provide error handling for save actions

### DIFF
--- a/tests/autosave.js
+++ b/tests/autosave.js
@@ -617,11 +617,50 @@ describe( 'Autosave', () => {
 					expect( pendingActions.hasAny ).to.be.true;
 					sinon.clock.tick( 1000 );
 				} )
-				.then( () => Promise.resolve() )
+				.then( runPromiseCycles )
 				.then( () => {
 					expect( pendingActions.hasAny ).to.be.false;
 					sinon.assert.calledOnce( serverActionSpy );
 					sinon.assert.calledOnce( serverActionStub );
+				} );
+		} );
+
+		it( 'should handle a situration when the save callback throw an error', () => {
+			const pendingActions = editor.plugins.get( PendingActions );
+			const successServerActionSpy = sinon.spy();
+			const serverActionStub = sinon.stub();
+
+			serverActionStub.onFirstCall()
+				.rejects( new Error( 'foo' ) );
+
+			serverActionStub.onSecondCall()
+				.callsFake( successServerActionSpy );
+
+			autosave.adapter = {
+				save: serverActionStub
+			};
+
+			editor.model.change( writer => {
+				writer.setSelection( writer.createRangeIn( editor.model.document.getRoot().getChild( 0 ) ) );
+				editor.model.insertContent( writer.createText( 'foo' ) );
+			} );
+
+			return editor.destroy()
+				.then( () => {
+					expect( pendingActions.hasAny ).to.be.true;
+				} )
+				.then( runPromiseCycles )
+				.then( () => {
+					expect( pendingActions.hasAny ).to.be.true;
+					sinon.assert.calledOnce( serverActionStub );
+					sinon.assert.notCalled( successServerActionSpy );
+				} )
+				.then( () => sinon.clock.tick( 1000 ) )
+				.then( runPromiseCycles )
+				.then( () => {
+					expect( pendingActions.hasAny ).to.be.false;
+					sinon.assert.calledTwice( serverActionStub );
+					sinon.assert.calledOnce( successServerActionSpy );
 				} );
 		} );
 	} );

--- a/tests/autosave.js
+++ b/tests/autosave.js
@@ -625,7 +625,7 @@ describe( 'Autosave', () => {
 				} );
 		} );
 
-		it( 'should handle a situration when the save callback throw an error', () => {
+		it( 'should handle a situration when the save callback throws an error', () => {
 			const pendingActions = editor.plugins.get( PendingActions );
 			const successServerActionSpy = sinon.spy();
 			const serverActionStub = sinon.stub();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Provided error handling for save actions. Closes ckeditor/ckeditor5#2546.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
